### PR TITLE
Improve tx data coverage, comments

### DIFF
--- a/dist/lib/helpers.js
+++ b/dist/lib/helpers.js
@@ -1,10 +1,15 @@
 "use strict";
+// Copyright (C) 2021 Edge Network Technologies Limited
+// Use of this source code is governed by a GNU GPL-style license
+// that can be found in the LICENSE.md file. All rights reserved.
 exports.__esModule = true;
 exports.urlsafe = exports.toQueryString = void 0;
+// Transform any simple object into a query string for use in URLs.
 var toQueryString = function (data) { return Object.keys(data)
     .map(function (key) { return key + "=" + (0, exports.urlsafe)(data[key]); })
     .join('&'); };
 exports.toQueryString = toQueryString;
+// Sanitize a value for use in URLs.
 var urlsafe = function (v) {
     if (typeof v === 'string')
         return v.replace(/ /g, '%20');

--- a/dist/lib/index.d.ts
+++ b/dist/lib/index.d.ts
@@ -1,6 +1,9 @@
 export * as stake from './stake';
 export * as tx from './tx';
 export * as wallet from './wallet';
+/**
+ * On-chain variables.
+ */
 export declare type Vars = {
     custodian_wallets: string[];
     host_stake_amount: number;
@@ -11,4 +14,11 @@ export declare type Vars = {
     stake_release_fee_wallet: string;
     hash: string;
 };
+/**
+ * Get on-chain variables.
+ *
+ * ```
+ * const mainnetVars = await vars('https://api.xe.network')
+ * ```
+ */
 export declare const vars: (host: string) => Promise<Vars>;

--- a/dist/lib/index.js
+++ b/dist/lib/index.js
@@ -1,4 +1,7 @@
 "use strict";
+// Copyright (C) 2021 Edge Network Technologies Limited
+// Use of this source code is governed by a GNU GPL-style license
+// that can be found in the LICENSE.md file. All rights reserved.
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
@@ -63,16 +66,23 @@ exports.stake = __importStar(require("./stake"));
 exports.tx = __importStar(require("./tx"));
 exports.wallet = __importStar(require("./wallet"));
 var superagent_1 = __importDefault(require("superagent"));
+/**
+ * Get on-chain variables.
+ *
+ * ```
+ * const mainnetVars = await vars('https://api.xe.network')
+ * ```
+ */
 var vars = function (host) { return __awaiter(void 0, void 0, void 0, function () {
     var url, response;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
                 url = host + "/vars";
-                return [4, superagent_1["default"].get(url)];
+                return [4 /*yield*/, superagent_1["default"].get(url)];
             case 1:
                 response = _a.sent();
-                return [2, response.body];
+                return [2 /*return*/, response.body];
         }
     });
 }); };

--- a/dist/lib/stake.d.ts
+++ b/dist/lib/stake.d.ts
@@ -13,4 +13,11 @@ export declare type Stake = {
 };
 export declare type Stakes = Record<string, Stake>;
 export declare type StakeType = 'gateway' | 'host' | 'stargate';
+/**
+ * Get stakes associated with a wallet address.
+ *
+ * ```
+ * const myStakes = await stakes('https://api.xe.network', 'my-wallet-address')
+ * ```
+ */
 export declare const stakes: (host: string, address: string) => Promise<Stakes>;

--- a/dist/lib/stake.js
+++ b/dist/lib/stake.js
@@ -1,4 +1,7 @@
 "use strict";
+// Copyright (C) 2021 Edge Network Technologies Limited
+// Use of this source code is governed by a GNU GPL-style license
+// that can be found in the LICENSE.md file. All rights reserved.
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -41,16 +44,23 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 exports.__esModule = true;
 exports.stakes = void 0;
 var superagent_1 = __importDefault(require("superagent"));
+/**
+ * Get stakes associated with a wallet address.
+ *
+ * ```
+ * const myStakes = await stakes('https://api.xe.network', 'my-wallet-address')
+ * ```
+ */
 var stakes = function (host, address) { return __awaiter(void 0, void 0, void 0, function () {
     var url, response;
     return __generator(this, function (_a) {
         switch (_a.label) {
             case 0:
                 url = host + "/stakes/" + address;
-                return [4, superagent_1["default"].get(url)];
+                return [4 /*yield*/, superagent_1["default"].get(url)];
             case 1:
                 response = _a.sent();
-                return [2, response.body];
+                return [2 /*return*/, response.body];
         }
     });
 }); };

--- a/dist/lib/tx.d.ts
+++ b/dist/lib/tx.d.ts
@@ -1,3 +1,8 @@
+/**
+ * API response for creating on-chain transactions.
+ *
+ * See `createTransactions()` for more usage information.
+ */
 export declare type CreateResponse = {
     results: CreateTxReceipt[];
     metadata: {
@@ -6,6 +11,9 @@ export declare type CreateResponse = {
         rejected?: number;
     };
 };
+/**
+ * Receipt for the creation of an on-chain transaction.
+ */
 export declare type CreateTxReceipt = Partial<Tx> & {
     success: boolean;
     status: number;
@@ -15,7 +23,15 @@ export declare type CreateTxReceipt = Partial<Tx> & {
     wallet_nonce?: number;
     transaction: Omit<Tx, 'hash'>;
 };
+/**
+ * Possible device actions that can be added to transaction data.
+ *
+ * See the `Tx` type and `createTransactions()` for more information.
+ */
 export declare type DeviceAction = 'assign_device' | 'unassign_device';
+/**
+ * API response template for a transactions query.
+ */
 export declare type ListResponse = {
     results: Tx[];
     metadata: {
@@ -24,15 +40,20 @@ export declare type ListResponse = {
         count: number;
     };
 };
-export declare type TxData = {
-    action?: DeviceAction | StakeAction;
-    device?: string;
-    express?: boolean;
-    memo?: string;
-    stake?: string;
-};
+/**
+ * Pre-chain, signed transaction.
+ * This includes everything except the hash.
+ */
 export declare type SignedTx = Omit<Tx, 'hash'>;
+/**
+ * Possible stake actions that can be added to transaction data.
+ *
+ * See the `Tx` type and `createTransactions()` for more information.
+ */
 export declare type StakeAction = 'create_stake' | 'release_stake' | 'unlock_stake';
+/**
+ * On-chain transaction.
+ */
 export declare type Tx = {
     timestamp: number;
     sender: string;
@@ -43,13 +64,126 @@ export declare type Tx = {
     hash: string;
     signature: string;
 };
+/**
+ * Bridge transaction data.
+ * These values should only be set in exchange transactions created by Bridge.
+ */
+export declare type TxBridgeData = {
+    /** Ethereum address for withdrawal/sale transaction. Used by Bridge. */
+    destination?: string;
+    /** Fee amount in an exchange transaction. Used by Bridge. */
+    fee?: number;
+    /** Exchange rate reference for sale transaction. Used by Bridge. */
+    ref?: string;
+};
+/**
+ * Transaction data.
+ */
+export declare type TxData = TxBridgeData & TxVarData & {
+    /** Blockchain action to be effected in the course of creating the transaction. */
+    action?: DeviceAction | StakeAction | VarAction;
+    /** Device ID. Use with `action: DeviceAction` */
+    device?: string;
+    /** Express unlock flag. Use with `action: "unlock_stake"` */
+    express?: boolean;
+    /** Transaction memo. Can be any string. */
+    memo?: string;
+    /** Stake ID. Use with `action: DeviceAction | "release_stake" | "unlock_stake"` */
+    stake?: string;
+};
+/**
+ * Variables transaction data.
+ * These values should only be set by a blockchain custodian when updating on-chain variables.
+ */
+export declare type TxVarData = {
+    /** Variable name. Use with `action: VarAction` */
+    key?: string;
+    /** Variable value. Use with `action: "set_var"` */
+    value?: unknown;
+};
+/**
+ * Parameters for a transactions query.
+ *
+ * Both `from` and `to` reflect block height.
+ */
 export declare type TxsParams = {
     from?: number;
     to?: number;
 };
+/**
+ * Pre-chain transaction that needs to be signed.
+ */
 export declare type UnsignedTx = Omit<Tx, 'hash' | 'signature'> & Partial<Pick<Tx, 'signature'>>;
+/**
+ * Possible variable setter actions. These are only usable by blockchain custodians.
+ */
+export declare type VarAction = 'set_var' | 'unset_var';
+/**
+ * Create one or more transactions on chain.
+ *
+ * Transactions must be signed, otherwise they will be rejected.
+ * Wallet addresses are assumed to be correct; any validation should take place in user code.
+ *
+ * This function can also be used for staking transactions, by setting for example `data: { action: 'create_stake' }`.
+ * Refer to staking documentation and the StakeAction type for more detail.
+ *
+ * ```
+ * const myTx = sign({
+ *   timestamp: Date.now(),
+ *   sender: 'my-wallet-address',
+ *   recipient: 'other-wallet-address',
+ *   amount: 1000,
+ *   data: { memo: 'example of sending 1 XE' },
+ *   nonce: 1
+ * }, 'my-private-key')
+ *
+ * const res = await createTransactions('https://api.xe.network', [myTx])
+ * ```
+ */
 export declare const createTransactions: (host: string, txs: SignedTx[]) => Promise<CreateResponse>;
+/**
+ * Get pending transactions.
+ *
+ * Pass a wallet address to get only pending transactions from that address.
+ *
+ * ```
+ * const allPendingTxs = await pendingTransactions('https://api.xe.network')
+ *
+ * const myPendingTxs = await pendingTransactions('https://api.xe.network', 'my-wallet-address')
+ * ```
+ */
 export declare const pendingTransactions: (host: string, address?: string | undefined) => Promise<Tx[]>;
+/**
+ * Sign a transaction with a wallet private key.
+ *
+ * When using this function, consider the input (unsigned) transaction to be 'consumed', and use only the signed
+ * transaction that is returned.
+ * The signed transaction should not be modified, otherwise its signature may be invalidated.
+ *
+ * ```
+ * const myTx = sign({
+ *   timestamp: Date.now(),
+ *   sender: 'my-wallet-address',
+ *   recipient: 'other-wallet-address',
+ *   amount: 1000,
+ *   data: { memo: 'example of sending 1 XE' },
+ *   nonce: 1
+ * }, 'my-private-key')
+ * ```
+ */
 export declare const sign: (tx: UnsignedTx, privateKey: string) => SignedTx;
+/**
+ * Prepare a signable transaction and signing message.
+ *
+ * Normally, user code should just use `sign()`.
+ */
 export declare const signable: (tx: UnsignedTx) => [UnsignedTx, string];
+/**
+ * Get recent transactions, or transactions within a specified block range.
+ *
+ * ```
+ * const recent = await tx.transactions('https://api.xe.network')
+ * const hist = await tx.transactions('https://api.xe.network', { from: 159335, to: 159345 })
+ * ```
+ */
 export declare const transactions: (host: string, params?: TxsParams | undefined) => Promise<ListResponse>;

--- a/dist/lib/tx.d.ts
+++ b/dist/lib/tx.d.ts
@@ -86,7 +86,7 @@ export declare type TxData = TxBridgeData & TxVarData & {
     device?: string;
     /** Express unlock flag. Use with `action: "unlock_stake"` */
     express?: boolean;
-    /** Transaction memo. Can be any string. */
+    /** Transaction memo. */
     memo?: string;
     /** Stake ID. Use with `action: DeviceAction | "release_stake" | "unlock_stake"` */
     stake?: string;

--- a/dist/lib/tx.js
+++ b/dist/lib/tx.js
@@ -1,4 +1,7 @@
 "use strict";
+// Copyright (C) 2021 Edge Network Technologies Limited
+// Use of this source code is governed by a GNU GPL-style license
+// that can be found in the LICENSE.md file. All rights reserved.
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -43,21 +46,54 @@ exports.transactions = exports.signable = exports.sign = exports.pendingTransact
 var wallet_1 = require("./wallet");
 var superagent_1 = __importDefault(require("superagent"));
 var helpers_1 = require("./helpers");
+/**
+ * Create one or more transactions on chain.
+ *
+ * Transactions must be signed, otherwise they will be rejected.
+ * Wallet addresses are assumed to be correct; any validation should take place in user code.
+ *
+ * This function can also be used for staking transactions, by setting for example `data: { action: 'create_stake' }`.
+ * Refer to staking documentation and the StakeAction type for more detail.
+ *
+ * ```
+ * const myTx = sign({
+ *   timestamp: Date.now(),
+ *   sender: 'my-wallet-address',
+ *   recipient: 'other-wallet-address',
+ *   amount: 1000,
+ *   data: { memo: 'example of sending 1 XE' },
+ *   nonce: 1
+ * }, 'my-private-key')
+ *
+ * const res = await createTransactions('https://api.xe.network', [myTx])
+ * ```
+ */
 var createTransactions = function (host, txs) { return __awaiter(void 0, void 0, void 0, function () {
     var response;
     return __generator(this, function (_a) {
         switch (_a.label) {
-            case 0: return [4, superagent_1["default"].post(host + "/transaction")
+            case 0: return [4 /*yield*/, superagent_1["default"].post(host + "/transaction")
                     .set('Accept', 'application/json')
                     .set('Content-Type', 'application/json')
                     .send(txs)];
             case 1:
                 response = _a.sent();
-                return [2, response.body];
+                return [2 /*return*/, response.body];
         }
     });
 }); };
 exports.createTransactions = createTransactions;
+/**
+ * Get pending transactions.
+ *
+ * Pass a wallet address to get only pending transactions from that address.
+ *
+ * ```
+ * const allPendingTxs = await pendingTransactions('https://api.xe.network')
+ *
+ * const myPendingTxs = await pendingTransactions('https://api.xe.network', 'my-wallet-address')
+ * ```
+ */
 var pendingTransactions = function (host, address) { return __awaiter(void 0, void 0, void 0, function () {
     var url, response;
     return __generator(this, function (_a) {
@@ -66,20 +102,43 @@ var pendingTransactions = function (host, address) { return __awaiter(void 0, vo
                 url = host + "/transactions/pending";
                 if (address !== undefined)
                     url += "/" + address;
-                return [4, superagent_1["default"].get(url)];
+                return [4 /*yield*/, superagent_1["default"].get(url)];
             case 1:
                 response = _a.sent();
-                return [2, response.body];
+                return [2 /*return*/, response.body];
         }
     });
 }); };
 exports.pendingTransactions = pendingTransactions;
+/**
+ * Sign a transaction with a wallet private key.
+ *
+ * When using this function, consider the input (unsigned) transaction to be 'consumed', and use only the signed
+ * transaction that is returned.
+ * The signed transaction should not be modified, otherwise its signature may be invalidated.
+ *
+ * ```
+ * const myTx = sign({
+ *   timestamp: Date.now(),
+ *   sender: 'my-wallet-address',
+ *   recipient: 'other-wallet-address',
+ *   amount: 1000,
+ *   data: { memo: 'example of sending 1 XE' },
+ *   nonce: 1
+ * }, 'my-private-key')
+ * ```
+ */
 var sign = function (tx, privateKey) {
     var _a = (0, exports.signable)(tx), controlTx = _a[0], message = _a[1];
     controlTx.signature = (0, wallet_1.generateSignature)(privateKey, message);
     return controlTx;
 };
 exports.sign = sign;
+/**
+ * Prepare a signable transaction and signing message.
+ *
+ * Normally, user code should just use `sign()`.
+ */
 var signable = function (tx) {
     var controlTx = {
         timestamp: tx.timestamp,
@@ -92,6 +151,14 @@ var signable = function (tx) {
     return [controlTx, JSON.stringify(controlTx)];
 };
 exports.signable = signable;
+/**
+ * Get recent transactions, or transactions within a specified block range.
+ *
+ * ```
+ * const recent = await tx.transactions('https://api.xe.network')
+ * const hist = await tx.transactions('https://api.xe.network', { from: 159335, to: 159345 })
+ * ```
+ */
 var transactions = function (host, params) { return __awaiter(void 0, void 0, void 0, function () {
     var url, response;
     return __generator(this, function (_a) {
@@ -100,10 +167,10 @@ var transactions = function (host, params) { return __awaiter(void 0, void 0, vo
                 url = host + "/transactions";
                 if (params !== undefined)
                     url += "?" + (0, helpers_1.toQueryString)(params);
-                return [4, superagent_1["default"].get(url)];
+                return [4 /*yield*/, superagent_1["default"].get(url)];
             case 1:
                 response = _a.sent();
-                return [2, response.body];
+                return [2 /*return*/, response.body];
         }
     });
 }); };

--- a/dist/lib/wallet.d.ts
+++ b/dist/lib/wallet.d.ts
@@ -1,25 +1,90 @@
 import elliptic from 'elliptic';
+/**
+ * A 'keypair' for an XE wallet.
+ *
+ * Internally, `publicKey` and `privateKey` constitute the keypair while the public `address` that is actually used is
+ * calculated from the public key. All three values are provided by this type.
+ */
 export declare type Wallet = {
     address: string;
     privateKey: string;
     publicKey: string;
 };
+/**
+ * Current on-chain wallet status.
+ *
+ * The `balance` represents the current available balance (so excluding stakes) and the `nonce` is the current or next
+ * nonce, depending on how wallet info is retrieved.
+ *
+ * See `info()` and `infoWithNextNonce()` for more usage information.
+ */
 export declare type WalletInfo = {
     address: string;
     balance: number;
     nonce: number;
 };
+/**
+ * Create a new wallet.
+ */
 export declare const create: () => Wallet;
+/**
+ * Derive a wallet address from its corresponding public key.
+ */
 export declare const deriveAddress: (publicKey: string) => string;
+/**
+ * Derive a wallet address from its corresponding private key.
+ */
 export declare const deriveAddressFromPrivateKey: (privateKey: string) => string;
+/**
+ * Derive a wallet address from a signed message.
+ */
 export declare const deriveAddressFromSignedMessage: (msg: string, signature: string) => string;
+/**
+ * Generate a message signature using a private key.
+ */
 export declare const generateSignature: (privateKey: string, msg: string) => string;
+/**
+ * Get current on-chain wallet information.
+ *
+ * ```
+ * const { balance } = await info('https://api.xe.network', 'my-wallet-address')
+ * ```
+ */
 export declare const info: (host: string, address: string) => Promise<WalletInfo>;
+/**
+ * Get on-chain wallet information with its next transaction nonce.
+ * This accounts for any pending transactions to ensure next nonce is correct.
+ *
+ * ```
+ * const { balance, nonce } = await info('https://api.xe.network', 'my-wallet-address')
+ * ```
+ */
 export declare const infoWithNextNonce: (host: string, address: string) => Promise<WalletInfo>;
+/**
+ * Parse signature to recover constituent data.
+ */
 export declare const parseSignature: (signature: string) => [elliptic.SignatureInput, number];
+/**
+ * Derive a public key from its matching private key.
+ */
 export declare const publicKeyFromPrivateKey: (privateKey: string) => string;
+/**
+ * Recover a public key from a signed message.
+ */
 export declare const publicKeyFromSignedMessage: (msg: string, signature: string) => string;
+/**
+ * Recover a wallet from its matching private key.
+ */
 export declare const recover: (privateKey: string) => Wallet;
+/**
+ * Validate the format of a wallet address.
+ */
 export declare const validateAddress: (address: string) => boolean;
+/**
+ * Validate the format of a private key.
+ */
 export declare const validatePrivateKey: (privateKey: string) => boolean;
+/**
+ * Validate a message-signature pair by comparing address input with recovered wallet address.
+ */
 export declare const validateSignatureAddress: (msg: string, signature: string, address: string) => boolean;

--- a/lib/tx.ts
+++ b/lib/tx.ts
@@ -104,7 +104,7 @@ export type TxData = TxBridgeData & TxVarData & {
   device?: string
   /** Express unlock flag. Use with `action: "unlock_stake"` */
   express?: boolean
-  /** Transaction memo. Can be any string. */
+  /** Transaction memo. */
   memo?: string
   /** Stake ID. Use with `action: DeviceAction | "release_stake" | "unlock_stake"` */
   stake?: string

--- a/lib/tx.ts
+++ b/lib/tx.ts
@@ -42,6 +42,9 @@ export type CreateTxReceipt = Partial<Tx> & {
  */
 export type DeviceAction = 'assign_device' | 'unassign_device'
 
+/**
+ * API response template for a transactions query.
+ */
 export type ListResponse = {
   results: Tx[]
   metadata: {
@@ -118,6 +121,11 @@ export type TxVarData = {
   value?: unknown
 }
 
+/**
+ * Parameters for a transactions query.
+ *
+ * Both `from` and `to` reflect block height.
+ */
 export type TxsParams = {
   from?: number
   to?: number

--- a/lib/tx.ts
+++ b/lib/tx.ts
@@ -52,17 +52,6 @@ export type ListResponse = {
 }
 
 /**
- * Transaction data.
- */
-export type TxData = {
-  action?: DeviceAction | StakeAction
-  device?: string
-  express?: boolean
-  memo?: string
-  stake?: string
-}
-
-/**
  * Pre-chain, signed transaction.
  * This includes everything except the hash.
  */
@@ -89,6 +78,46 @@ export type Tx = {
   signature: string
 }
 
+/**
+ * Bridge transaction data.
+ * These values should only be set in exchange transactions created by Bridge.
+ */
+export type TxBridgeData = {
+  /** Ethereum address for withdrawal/sale transaction. Used by Bridge. */
+  destination?: string
+  /** Fee amount in an exchange transaction. Used by Bridge. */
+  fee?: number
+  /** Exchange rate reference for sale transaction. Used by Bridge. */
+  ref?: string
+}
+
+/**
+ * Transaction data.
+ */
+export type TxData = TxBridgeData & TxVarData & {
+  /** Blockchain action to be effected in the course of creating the transaction. */
+  action?: DeviceAction | StakeAction | VarAction
+  /** Device ID. Use with `action: DeviceAction` */
+  device?: string
+  /** Express unlock flag. Use with `action: "unlock_stake"` */
+  express?: boolean
+  /** Transaction memo. Can be any string. */
+  memo?: string
+  /** Stake ID. Use with `action: DeviceAction | "release_stake" | "unlock_stake"` */
+  stake?: string
+}
+
+/**
+ * Variables transaction data.
+ * These values should only be set by a blockchain custodian when updating on-chain variables.
+ */
+export type TxVarData = {
+  /** Variable name. Use with `action: VarAction` */
+  key?: string
+  /** Variable value. Use with `action: "set_var"` */
+  value?: unknown
+}
+
 export type TxsParams = {
   from?: number
   to?: number
@@ -98,6 +127,11 @@ export type TxsParams = {
  * Pre-chain transaction that needs to be signed.
  */
 export type UnsignedTx = Omit<Tx, 'hash' | 'signature'> & Partial<Pick<Tx, 'signature'>>
+
+/**
+ * Possible variable setter actions. These are only usable by blockchain custodians.
+ */
+export type VarAction = 'set_var' | 'unset_var'
 
 /**
  * Create one or more transactions on chain.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "noImplicitAny": true,
     "outDir": "dist",
     "preserveConstEnums": true,
-    "removeComments": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true


### PR DESCRIPTION
This update provides more coverage of possible transaction data, plus deeper documentation for individual values. This should make it a bit easier to work with transaction data across various applications.

I also added doc comments for a couple of types I overlooked.

I've also tweaked the tsconfig.json to enable comments in generated code. This slightly increases the dist size, but allows Intellisense to access typedoc comments in user code, as pictured:

![image](https://user-images.githubusercontent.com/129557/140937010-f7eafe86-a1c3-41bd-a28b-d04c1e735d60.png)
