### PR TITLE
Fix: left pad private keys to ensure length of 64 characters

### DIFF
--- a/lib/wallet.ts
+++ b/lib/wallet.ts
@@ -66,7 +66,7 @@ const ec = new elliptic.ec('secp256k1')
  */
 export const create = (): Wallet => {
   const keyPair = ec.genKeyPair()
-  const privateKey = keyPair.getPrivate('hex').toString()
+  const privateKey = padPrivateKey(keyPair.getPrivate('hex').toString())
   const publicKey = keyPair.getPublic(true, 'hex').toString()
   const address = deriveAddress(publicKey)
   return { address, privateKey, publicKey }
@@ -134,6 +134,10 @@ export const infoWithNextNonce = async (host: string, address: string, cb?: Requ
   return walletInfo
 }
 
+/** Pad private key with leading zeroes, if necessary, to ensure it is the expected length. */
+export const padPrivateKey = (privateKey: string): string =>
+  privateKey.length === 64 ? privateKey : privateKey.padStart(64, '0')
+
 /**
  * Parse signature to recover constituent data.
  */
@@ -166,7 +170,7 @@ export const publicKeyFromSignedMessage = (msg: string, signature: string): stri
 export const recover = (privateKey: string): Wallet => {
   const publicKey = publicKeyFromPrivateKey(privateKey)
   const address = deriveAddress(publicKey)
-  return { address, privateKey, publicKey }
+  return { address, privateKey: padPrivateKey(privateKey), publicKey }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,16 +12,21 @@
     "build": "tsc",
     "lint": "eslint --ext .ts lib",
     "lint:fix": "eslint --fix --ext .ts lib",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' mocha -r ts-node/register 'tests/**/*.ts'"
   },
   "devDependencies": {
     "@edge/eslint-config-typescript": "^0.1.1",
+    "@types/chai": "^4.3.11",
     "@types/crypto-js": "^4.0.2",
     "@types/elliptic": "^6.4.13",
+    "@types/mocha": "^10.0.6",
     "@types/superagent": "^4.1.13",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
+    "chai": "^4.4.1",
     "eslint": "^7.32.0",
+    "mocha": "^9.2.2",
+    "ts-node": "^10.9.2",
     "typescript": "^4.4.3"
   },
   "dependencies": {

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,0 +1,25 @@
+import * as lib from '../lib'
+import { expect } from 'chai'
+
+const maxWallets = 1000000
+
+describe('Wallet', () => {
+  it('should always have a valid and recoverable private key', function () {
+    this.timeout(0)
+
+    for (let i = 0; i < maxWallets; i++) {
+      const wallet = lib.wallet.create()
+
+      expect(lib.wallet.validatePrivateKey(wallet.privateKey))
+        .to
+        .equal(true,`Invalid private key "${wallet.privateKey}" after ${i} iterations for (address: ${wallet.address})`)
+
+      const recoveredWallet = lib.wallet.recover(wallet.privateKey)
+      expect(recoveredWallet.address).to.equal(wallet.address)
+
+      if (i > 0 && i % 10000 === 0) console.log(`Generated ${i.toLocaleString()} private keys so far`)
+    }
+
+    console.log(`Done after generating ${maxWallets.toLocaleString()} valid private keys`)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   },
   "include": [
     "lib/**/*",
+    "tests/**/*",
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
We recently discovered an issue where validation in certain apps prevented usage of 62-character private keys. Such keys are generated when their first byte is a zero, which is stripped when encoding as hex.

This doesn't cause any issues with the underlying cryptography or usage thereof but for internal consistency and predictability it is simpler for us to enforce 64-character private keys, so this patch treats it as a formatting issue and manually left-pads short private keys with additional 0s.

I have also added a test which generates 1mil private keys and validates them using the library function. For additional confidence, it also recovers the wallet based on the padded private key and ensures they are equivalent by comparing input and result wallet addresses. I've run this twice without issue locally, indicating the fix is appropriate and won't cause any problems.

This patch will be reproduced for [wallet-utils](https://github.com/edge/wallet-utils/) after apps using xe-utils have been updated.